### PR TITLE
Bochs: 8GB ram

### DIFF
--- a/bochs/config.cc
+++ b/bochs/config.cc
@@ -699,7 +699,7 @@ void bx_init_options()
       "host_size",
       "Host allocated memory size (megabytes)",
       "Amount of host allocated memory in megabytes",
-      1, 2048,
+      1, 8 * 1024,
       BX_DEFAULT_MEM_MEGS);
   host_ramsize->set_ask_format("Enter host memory size (MB): [%d] ");
   ram->set_options(ram->SERIES_ASK);

--- a/bochs/memory/misc_mem.cc
+++ b/bochs/memory/misc_mem.cc
@@ -57,7 +57,7 @@ BX_MEM_C::BX_MEM_C()
 Bit8u* BX_MEM_C::alloc_vector_aligned(Bit64u bytes, Bit64u alignment)
 {
   Bit64u test_mask = alignment - 1;
-  BX_MEM_THIS actual_vector = new Bit8u [(Bit32u)(bytes + test_mask)];
+  BX_MEM_THIS actual_vector = new Bit8u [bytes + test_mask];
   if (BX_MEM_THIS actual_vector == 0) {
     BX_PANIC(("alloc_vector_aligned: unable to allocate host RAM !"));
     return 0;


### PR DESCRIPTION
I did this for a project of mine and it seems to work (lol).
Bochs uses Bit32u only for block indexes and to count used_blocks (if I'm correct) so it should be fine.
Blocks are 4MB-long so that should leave enough bits to keep the Bit32u working (4GB ram overflows the `Bit32u` cast in the memory allocation and that seems to be the only issue in increasing the mem size).
I think that for reasonable quantities of RAM this should be fine.

Of course I might be wrong :)

A simple test would be to write a dumb OS that reads/writes all mem but I couldn't be bothered :P

EDIT: I should add that I'm developing on Linux so I didn't actually compile and tried stuff with applepie unfortunately.